### PR TITLE
Fix: UserPassword is not saved

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
@@ -107,9 +107,6 @@ public final class MQNotifierConfig extends GlobalConfiguration {
     @Override
     public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
         req.bindJSON(this, formData);
-        if (formData.has("persistentDelivery")) {
-            this.persistentDelivery = formData.getBoolean("persistentDelivery");
-        }
         save();
         return true;
     }
@@ -157,6 +154,15 @@ public final class MQNotifierConfig extends GlobalConfiguration {
      */
     public Secret getUserPassword() {
         return this.userPassword;
+    }
+
+    /**
+     * Sets user password.
+     *
+     * @param userPassword the user password.
+     */
+    public void setUserPassword(Secret userPassword) {
+        this.userPassword = userPassword;
     }
 
     /**
@@ -236,7 +242,7 @@ public final class MQNotifierConfig extends GlobalConfiguration {
      *
      * @param pd if persistentDelivery is to be used.
      */
-    public void setDeliveryMode(boolean pd) {
+    public void setPersistentDelivery(boolean pd) {
         this.persistentDelivery = pd;
     }
 


### PR DESCRIPTION
Since the userPassword field was missing a matching set:er,
the req.bindJSON() could not store the form posted password
in MQNotifierConfig.

For similiar reasons, the persistentDelivery needed extra
handling in configure() since the set:er name did not match
the field name.
