### PR TITLE
Added an extension point for providing Data to the notifier

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/QueueListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/QueueListenerImpl.java
@@ -24,6 +24,7 @@
 package com.sonymobile.jenkins.plugins.mq.mqnotifier;
 
 import com.rabbitmq.client.AMQP;
+import com.sonymobile.jenkins.plugins.mq.mqnotifier.providers.MQDataProvider;
 import hudson.Extension;
 import hudson.model.Queue;
 import hudson.model.queue.QueueListener;
@@ -46,12 +47,9 @@ public class QueueListenerImpl extends QueueListener {
         JSONObject json = new JSONObject();
         json.put(Util.KEY_STATE, Util.VALUE_ADDED_TO_QUEUE);
         json.put(Util.KEY_URL, Util.getJobUrl(wi));
-        String[] parametersArray = new String[0];
-        String parameters = wi.getParams();
-        if (parameters.length() > 0) {
-            parametersArray = parameters.substring(1).split("\n");   // Remove leading '\n'.
+        for (MQDataProvider mqDataProvider : MQDataProvider.all()) {
+            mqDataProvider.provideEnterWaitingQueueData(wi, json);
         }
-        json.put(Util.KEY_PARAMETERS, parametersArray);
         publish(json);
     }
 
@@ -65,12 +63,10 @@ public class QueueListenerImpl extends QueueListener {
             json.put(Util.KEY_DEQUEUE_REASON, Util.VALUE_BUILDING);
         }
         json.put(Util.KEY_URL, Util.getJobUrl(li));
-        String[] parametersArray = new String[0];
-        String parameters = li.getParams();
-        if (parameters.length() > 0) {
-            parametersArray = parameters.substring(1).split("\n");   // Remove leading '\n'.
+
+        for (MQDataProvider mqDataProvider : MQDataProvider.all()) {
+            mqDataProvider.provideLeftQueueData(li, json);
         }
-        json.put(Util.KEY_PARAMETERS, parametersArray);
         publish(json);
     }
 

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/Util.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/Util.java
@@ -38,14 +38,10 @@ public final class Util {
     public static final String KEY_URL = "url";
     /**State Key. */
     public static final String KEY_STATE = "state";
-    /**Causes Key. */
-    public static final String KEY_CAUSES = "causes";
     /**Dequeue Reason Key. */
     public static final String KEY_DEQUEUE_REASON = "dequeue_reason";
     /**Status Key. */
     public static final String KEY_STATUS = "status";
-    /**Params Key. */
-    public static final String KEY_PARAMETERS = "parameters";
     /**Queued Value. */
     public static final String VALUE_ADDED_TO_QUEUE = "QUEUED";
     /**Dequeued Value. */

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/providers/CauseProvider.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/providers/CauseProvider.java
@@ -1,0 +1,80 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2017 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.jenkins.plugins.mq.mqnotifier.providers;
+
+import hudson.Extension;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Run;
+import hudson.model.TopLevelItem;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Provides information about the causes for a build.
+ *
+ * @author Tomas Westling &lt;tomas.westling@axis.com&gt;
+ */
+@Extension
+public class CauseProvider extends MQDataProvider {
+
+    /**Causes Key. */
+    public static final String KEY_CAUSES = "causes";
+
+    @Override
+    public void provideStartRunData(Run run, JSONObject json) {
+
+        List<String> causes = new LinkedList<String>();
+        for (Object o : run.getCauses()) {
+            causes.add(o.getClass().getSimpleName());
+        }
+
+        for (Cause cause : run.getAction(CauseAction.class).getCauses()) {
+            if (cause instanceof Cause.UpstreamCause) {
+                Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause)cause;
+                causes.add(upstreamCause.getShortDescription());
+                TopLevelItem item = Jenkins.getInstance().getItem(upstreamCause.getUpstreamProject());
+                if (item != null && item instanceof MatrixProject) {
+                    //Find the build
+                    MatrixBuild mb = ((MatrixProject)item).getBuildByNumber(upstreamCause.getUpstreamBuild());
+                    causes.add(mb.getUrl());
+                }
+            }
+        }
+        Cause.RemoteCause remoteCause = (Cause.RemoteCause)run.getCause(Cause.RemoteCause.class);
+        if (remoteCause != null) {
+            causes.add(remoteCause.getShortDescription());
+        }
+        Cause.UserIdCause userIdCause = (Cause.UserIdCause)run.getCause(Cause.UserIdCause.class);
+        if (userIdCause != null) {
+            causes.add(userIdCause.getShortDescription());
+        }
+        json.put(KEY_CAUSES, causes.toString());
+    }
+}

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/providers/MQDataProvider.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/providers/MQDataProvider.java
@@ -1,0 +1,84 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2017 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.jenkins.plugins.mq.mqnotifier.providers;
+
+import hudson.ExtensionPoint;
+import hudson.model.Queue;
+import hudson.model.Run;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+
+import java.util.List;
+
+/**
+ * Provides data for the notifier to send.
+ *
+ * @author Tomas Westling &lt;tomas.westling@axis.com&gt;
+ */
+public abstract class MQDataProvider implements ExtensionPoint {
+
+    /**
+     * Provides data for when an item enters the queue.
+     *
+     * @param wi the {@link hudson.model.Queue.WaitingItem} that has entered the queue.
+     * @param json the json object that we should add information to.
+     */
+    public void provideEnterWaitingQueueData(Queue.WaitingItem wi, JSONObject json) {
+    }
+
+    /**
+     * Provides data for when an item leaves the queue.
+     *
+     * @param li the {@link hudson.model.Queue.LeftItem} that has left the queue.
+     * @param json the json object that we should add information to.
+     */
+    public void provideLeftQueueData(Queue.LeftItem li, JSONObject json) {
+    }
+
+    /**
+     * Provides data for when a Run starts.
+     *
+     * @param run the {@link hudson.model.Run} that has started running.
+     * @param json the json object that we should add information to.
+     */
+    public void provideStartRunData(Run run, JSONObject json) {
+    }
+
+    /**
+     * Provides data for when a Run is completed.
+     *
+     * @param run the {@link hudson.model.Run} that has completed running.
+     * @param json the json object that we should add information to.
+     */
+    public void provideCompletedRunData(Run run, JSONObject json) {
+    }
+
+    /**
+     * Returns all MQDataProvider for this Jenkins instance.
+     * @return all the MQDataProviders.
+     */
+    public static List<MQDataProvider> all() {
+        return Jenkins.getInstance().getExtensionList(MQDataProvider.class);
+    }
+}

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/providers/ParameterProvider.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/providers/ParameterProvider.java
@@ -1,0 +1,97 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2017 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.jenkins.plugins.mq.mqnotifier.providers;
+
+import hudson.Extension;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Queue;
+import hudson.model.Run;
+import net.sf.json.JSONObject;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Provides the notifier with build parameters.
+ */
+@Extension
+public class ParameterProvider extends MQDataProvider {
+
+    /**Params Key. */
+    public static final String KEY_PARAMETERS = "parameters";
+
+    @Override
+    public void provideStartRunData(Run run, JSONObject json) {
+        addRunParametersToJSON(run, json);
+    }
+
+    @Override
+    public void provideCompletedRunData(Run run, JSONObject json) {
+        addRunParametersToJSON(run, json);
+    }
+
+    @Override
+    public void provideEnterWaitingQueueData(Queue.WaitingItem wi, JSONObject json) {
+        addQueueParametersToJson(wi, json);
+    }
+
+    @Override
+    public void provideLeftQueueData(Queue.LeftItem li, JSONObject json) {
+        super.provideLeftQueueData(li, json);
+    }
+
+    /**
+     * Adds parameters for a Run.
+     * @param run the Run we are getting parameters from.
+     * @param json the JSON object to add data to.
+     */
+    private void addRunParametersToJSON(Run run, JSONObject json) {
+        List<String> parameters = new LinkedList<String>();
+        ParametersAction parametersAction = run.getAction(ParametersAction.class);
+        if (parametersAction != null) {
+            List<ParameterValue> parameterValues = parametersAction.getParameters();
+            if (parameterValues != null) {
+                for (ParameterValue parameterValue : parameterValues) {
+                    parameters.add(parameterValue.getName() + "=" + parameterValue.getValue());
+                }
+            }
+        }
+        json.put(KEY_PARAMETERS, parameters);
+    }
+
+    /**
+     * Adds parameters for a {@link Queue.Item}s
+     * @param item the Item we are getting parameters from.
+     * @param json the JSON object to add data to.
+     */
+    private void addQueueParametersToJson(Queue.Item item, JSONObject json) {
+        String[] parametersArray = new String[0];
+        String parameters = item.getParams();
+        if (parameters.length() > 0) {
+            parametersArray = parameters.substring(1).split("\n");   // Remove leading '\n'.
+        }
+        json.put(KEY_PARAMETERS, parametersArray);
+    }
+}


### PR DESCRIPTION
The extension point MQDataProvider is now available. Other plugins
can extend this extension point if they have information about a Run
or a Queue.Item.
Added CauseProvider to add data regarding causes and ParameterProvider
to add data regarding parameters.