### PR TITLE
Added null check when assembling upstream causes

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/QueueListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/QueueListenerImpl.java
@@ -49,7 +49,7 @@ public class QueueListenerImpl extends QueueListener {
      * @param json The resulting JSONObject
      * @param i queue item
      */
-    public void populateCommon(JSONObject json, Queue.Item i){
+    public void populateCommon(JSONObject json, Queue.Item i) {
         json.put(Util.KEY_URL, Util.getJobUrl(i));
         json.put(Util.KEY_PROJECT_NAME, Util.getFullName(i.task));
         json.put(Util.KEY_MASTER_FQDN, Util.getHostName());

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/providers/CauseProvider.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/providers/CauseProvider.java
@@ -55,15 +55,18 @@ public class CauseProvider extends MQDataProvider {
             causes.add(o.getClass().getSimpleName());
         }
 
-        for (Cause cause : run.getAction(CauseAction.class).getCauses()) {
-            if (cause instanceof Cause.UpstreamCause) {
-                Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause)cause;
-                causes.add(upstreamCause.getShortDescription());
-                TopLevelItem item = Jenkins.getInstance().getItem(upstreamCause.getUpstreamProject());
-                if (item != null && item instanceof MatrixProject) {
-                    //Find the build
-                    MatrixBuild mb = ((MatrixProject)item).getBuildByNumber(upstreamCause.getUpstreamBuild());
-                    causes.add(mb.getUrl());
+        CauseAction causeAction = run.getAction(CauseAction.class);
+        if (causeAction != null) {
+            for (Cause cause : causeAction.getCauses()) {
+                if (cause instanceof Cause.UpstreamCause) {
+                    Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause)cause;
+                    causes.add(upstreamCause.getShortDescription());
+                    TopLevelItem item = Jenkins.getInstance().getItem(upstreamCause.getUpstreamProject());
+                    if (item != null && item instanceof MatrixProject) {
+                        //Find the build
+                        MatrixBuild mb = ((MatrixProject)item).getBuildByNumber(upstreamCause.getUpstreamBuild());
+                        causes.add(mb.getUrl());
+                    }
                 }
             }
         }


### PR DESCRIPTION
The CauseAction for the run could be null, which threw a
NullPointerException in some scenarios. Added a check.