### PR TITLE
Add "Build Duration" time to the published AMQP event

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/RunListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/RunListenerImpl.java
@@ -76,6 +76,7 @@ public class RunListenerImpl extends RunListener<Run> {
         json.put(Util.KEY_URL, Util.getJobUrl(r));
         json.put(Util.KEY_PROJECT_NAME, r.getParent().getFullName());
         json.put(Util.KEY_BUILD_NR, r.getNumber());
+        json.put(Util.KEY_BUILD_DURATION, r.getDuration());
         json.put(Util.KEY_MASTER_FQDN, Util.getHostName());
         String status = "";
         Result res = r.getResult();

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/Util.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/Util.java
@@ -45,6 +45,8 @@ public final class Util {
     public static final String KEY_PROJECT_NAME = "build_job_name";
     /**BuildNr Key. */
     public static final String KEY_BUILD_NR = "build_number";
+    /**Build Duration Key. */
+    public static final String KEY_BUILD_DURATION = "build_duration";
     /**Master FQDN Key. */
     public static final String KEY_MASTER_FQDN = "jenkins_master_fqdn";
     /**State Key. */


### PR DESCRIPTION
This change will help Jenkins operation teams to have
a better understanding around the duration of any
specific jobs when they are completed. They can directly
relate this information to cost when the underlying
executor resources are billed by time.
e.g. hourly rate applied to slaves based on on-demand AWS EC2

At SoMC, we intend to ship and index all the events coming
into the configured RabbitMQ exchange to our Elasticsearch
server so that we can analyze and visualize the data to
improve our daily operation.