### PR TITLE
Add an option to disable/enable the plugin

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ItemListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ItemListenerImpl.java
@@ -50,8 +50,10 @@ public class ItemListenerImpl extends ItemListener {
     public final void onLoaded() {
         LOGGER.info("All jobs have been loaded.");
         MQNotifierConfig config = MQNotifierConfig.getInstance();
-        MQConnection.getInstance().initialize(config.getUserName(), config.getUserPassword(),
-                config.getServerUri(), config.getVirtualHost());
+        if (config != null && config.isNotifierEnabled()) {
+            MQConnection.getInstance().initialize(config.getUserName(), config.getUserPassword(),
+                    config.getServerUri(), config.getVirtualHost());
+        }
         super.onLoaded();
     }
 }

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
@@ -58,6 +58,9 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
     private static final String USERNAME = "userName";
     private static final String PASSWORD = "userPassword";
 
+    /* The status whether the plugin is enabled */
+    private boolean enableNotifier;
+
     /* The MQ server URI */
     private String serverUri;
     private String userName;
@@ -81,6 +84,7 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
     /**
      * Creates an instance with specified parameters.
      *
+     * @param enableNotifier     if this plugin is enabled
      * @param serverUri          the server uri
      * @param userName           the user name
      * @param userPassword       the user password
@@ -91,8 +95,10 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
      * @param appId              the application id
      */
     @DataBoundConstructor
-    public MQNotifierConfig(String serverUri, String userName, Secret userPassword, String exchangeName,
-                            String virtualHost, String routingKey, boolean persistentDelivery, String appId) {
+    public MQNotifierConfig(boolean enableNotifier, String serverUri, String userName, Secret userPassword,
+                            String exchangeName, String virtualHost, String routingKey, boolean persistentDelivery,
+                            String appId) {
+        this.enableNotifier = enableNotifier;
         this.serverUri = serverUri;
         this.userName = userName;
         this.userPassword = userPassword;
@@ -115,6 +121,7 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
      * Load configuration on invoke.
      */
     public MQNotifierConfig() {
+        this.enableNotifier = false;    // default value
         this.persistentDelivery = true; // default value
     }
 
@@ -124,6 +131,24 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
         req.bindJSON(this, formData);
         save();
         MQConnection.getInstance().initialize(userName, userPassword, serverUri, virtualHost);
+    }
+
+    /**
+     * Gets whether this plugin is enabled or not.
+     *
+     * @return true if this plugin is enabled.
+     */
+    public boolean isNotifierEnabled() {
+        return this.enableNotifier;
+    }
+
+    /**
+     * Sets flag whether this plugin is enabled or not.
+     *
+     * @param enableNotifier true if this plugin is enabled.
+     */
+    public void setEnableNotifier(boolean enableNotifier) {
+        this.enableNotifier = enableNotifier;
     }
 
     /**

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/QueueListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/QueueListenerImpl.java
@@ -97,7 +97,7 @@ public class QueueListenerImpl extends QueueListener {
         if (config == null) {
             config = MQNotifierConfig.getInstance();
         }
-        if (config != null) {
+        if (config != null && config.isNotifierEnabled()) {
             AMQP.BasicProperties.Builder bob = new AMQP.BasicProperties.Builder();
             int dm = 1;
             if (config.getPersistentDelivery()) {

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/RunListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/RunListenerImpl.java
@@ -115,7 +115,7 @@ public class RunListenerImpl extends RunListener<Run> {
         if (config == null) {
             config = MQNotifierConfig.getInstance();
         }
-        if (config != null) {
+        if (config != null && config.isNotifierEnabled()) {
             AMQP.BasicProperties.Builder bob = new AMQP.BasicProperties.Builder();
             int dm = 1;
             if (config.getPersistentDelivery()) {

--- a/src/main/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig/config.groovy
+++ b/src/main/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig/config.groovy
@@ -28,6 +28,9 @@ def l = "/plugin/mq-notifier/"
 
 f.section(title: "MQ Notifier") {
 
+    f.entry(title: "Enable Notifier", help: l+"help-enable-notifier.html") {
+        f.checkbox(field: "enableNotifier", checked: my.enableNotifier)
+    }
     f.entry(title: "MQ URI", field: "serverUri", help: l+"help-amqp-uri.html") {
         f.textbox("value":my.serverUri)
     }

--- a/src/main/webapp/help-enable-notifier.html
+++ b/src/main/webapp/help-enable-notifier.html
@@ -1,0 +1,3 @@
+<div>
+    Mark if MQ notifer plugin should be enabled.
+</div>

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
@@ -79,7 +79,30 @@ public class PluginTest {
     }
 
     /**
-     * Test connection by sending a message.
+     * Test invalid connection by sending a message.
+     */
+    @Test
+    public void testInvalidConnection() {
+        MQConnection conn = MQConnection.getInstance();
+        MQNotifierConfig config = MQNotifierConfig.getInstance();
+        assertNotNull("No config available: MQNotifierConfig", config);
+        config.setExchangeName(EXCHANGE);
+        config.setServerUri(URI);
+        config.setRoutingKey(ROUTING);
+        config.setVirtualHost(null);
+        config.setEnableNotifier(false);
+
+        if (config != null && config.isNotifierEnabled()) {
+            conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
+            String message = new String(MESSAGE);
+
+            conn.addMessageToQueue(config.getExchangeName(), config.getRoutingKey(), null, message.getBytes());
+        }
+        assertEquals("Unmatched number of messages", 0, Mocks.MESSAGES.size());
+    }
+
+    /**
+     * Test valid connection by sending a message.
      */
     @Test
     public void testConnection() {
@@ -90,11 +113,14 @@ public class PluginTest {
         config.setServerUri(URI);
         config.setRoutingKey(ROUTING);
         config.setVirtualHost(null);
+        config.setEnableNotifier(true);
 
-        conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
-        String message = new String(MESSAGE);
+        if (config != null && config.isNotifierEnabled()) {
+            conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
+            String message = new String(MESSAGE);
 
-        conn.addMessageToQueue(config.getExchangeName(), config.getRoutingKey(), null, message.getBytes());
+            conn.addMessageToQueue(config.getExchangeName(), config.getRoutingKey(), null, message.getBytes());
+        }
         assertEquals("Unmatched number of messages", 1, Mocks.MESSAGES.size());
         assertThat("Unmatched message contents", Mocks.MESSAGES.get(0), is(MESSAGE));
     }


### PR DESCRIPTION
Currently the only way to invalidate the functionality provided
by this plugin is to uninstall it. There is no way to save the
parameter values while kept the plugin disabled.

Adding a checkbox and being able to turn the plugin on and off
is beneficial for troubleshooting purpose.