### PR TITLE
Step to allow publishing of arbitrary messages from pipeline jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,24 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.17</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.45</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.14</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
       <version>3.4.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-    <version>1.580.1</version>
-    <relativePath />
+    <version>2.37</version>
+    <relativePath/>
   </parent>
+
   <groupId>com.sonymobile.jenkins.plugins.mq</groupId>
   <artifactId>mq-notifier</artifactId>
   <version>1.2.8-SNAPSHOT</version>
   <packaging>hpi</packaging>
+
+  <properties>
+    <jenkins.version>2.73.3</jenkins.version>
+    <java.level>8</java.level>
+    <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
+  </properties>
 
   <name>MQ Notifier</name>
   <description>Publishes messages on an MQ server</description>
@@ -77,50 +85,42 @@
     </pluginRepository>
   </pluginRepositories>
 
-  <properties>
-    <jmockit.version>1.5</jmockit.version>
-    <junit.version>4.11</junit.version>
-    <amqp.client.version>3.4.1</amqp.client.version>
-    <commons.validator.version>1.4.0</commons.validator.version>
-    <commons.lang3.version>3.1</commons.lang3.version>
-  </properties>
   <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.16</version>
+    </dependency>
     <dependency>
       <groupId>com.googlecode.jmockit</groupId>
       <artifactId>jmockit</artifactId>
-      <version>${jmockit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>1.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>${amqp.client.version}</version>
+      <version>3.4.1</version>
     </dependency>
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
-      <version>${commons.validator.version}</version>
+      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${commons.lang3.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.7</version>
+      <version>3.4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.4</version>
+      <version>1.11</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-digester</groupId>
+      <artifactId>commons-digester</artifactId>
+      <version>2.1</version>
     </dependency>
   </dependencies>
   <build>
@@ -194,6 +194,13 @@
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/pipeline/MQMessageStep.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/pipeline/MQMessageStep.java
@@ -1,0 +1,130 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2018 Axis Communications AB
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.jenkins.plugins.mq.mqnotifier.pipeline;
+
+import com.sonymobile.jenkins.plugins.mq.mqnotifier.MQConnection;
+import hudson.Extension;
+import hudson.model.TaskListener;
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Pipeline step to allowing publication of a MQ message.
+ */
+public class MQMessageStep extends Step {
+    private final String json;
+
+    /**
+     * DataBoundConstructor.
+     *
+     * @param json mq message payload
+     */
+    @DataBoundConstructor
+    public MQMessageStep(String json) {
+        this.json = json;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new Execution(this, context);
+    }
+
+    /**
+     * @return the json payload
+     */
+    public String getJson() {
+        return json;
+    }
+
+    /**
+     * Simple synchronous step execution.
+     */
+    private static class Execution extends SynchronousStepExecution<Void> {
+
+        private transient MQMessageStep step;
+
+        /**
+         * Execution Constructor
+         *
+         * @param step    step
+         * @param context the step context
+         */
+        protected Execution(@Nonnull MQMessageStep step, StepContext context) {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            TaskListener listener = getContext().get(TaskListener.class);
+
+            JSONObject json;
+            try {
+                json = JSONObject.fromObject(step.getJson());
+            } catch (JSONException jsonException) {
+                listener.error("Not correct JSON: " + step.getJson());
+                throw jsonException;
+            }
+            // It would be preferable if we could wait for the message to be sent to RabbitMQ and let the
+            // user know in the build log if it could not be published for whatever reason. But every
+            // message is put on a queue to be sent at a later point in time. Preferably we would be able
+            // to get a Future<> back so that we could wait if we wanted. But that's not how the MQ
+            // Notifier is built.
+            listener.getLogger().println("Posting JSON message to RabbitMQ:\n" + json.toString(2));
+            MQConnection.getInstance().publish(json);
+            return null;
+        }
+    }
+
+    /**
+     * Standard Descriptor.
+     */
+    @Extension
+    public static class Descriptor extends StepDescriptor {
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "publishMQMessage";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Publish MQ Message";
+        }
+    }
+}

--- a/src/main/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/pipeline/MQMessageStep/config.groovy
+++ b/src/main/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/pipeline/MQMessageStep/config.groovy
@@ -1,0 +1,11 @@
+package com.sonymobile.jenkins.plugins.mq.mqnotifier.pipeline.MQMessageStep
+
+import lib.FormTagLib
+
+def f = namespace(FormTagLib)
+
+f.entry(field: 'json',
+        title: 'JSON Message',
+        description: 'JSON Message to be sent to the RabbitMQ server.') {
+    f.textbox()
+}

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
@@ -175,7 +175,7 @@ public class PluginTest {
         String label = "label";
         String axis1 = "one";
         String axis2 = "two";
-        MatrixProject project = j.createMatrixProject();
+        MatrixProject project = j.createProject(MatrixProject.class);
         Axis axis = new Axis(label, axis1, axis2);
         project.setAxes(new AxisList(axis));
 

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
@@ -28,6 +28,9 @@ import hudson.matrix.AxisList;
 import hudson.matrix.MatrixProject;
 import hudson.model.FreeStyleProject;
 import hudson.slaves.DumbSlave;
+import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -59,6 +62,7 @@ public class PluginTest {
 
     /**
      * Called before class is setup.
+     *
      * @throws Exception thrown
      */
     @BeforeClass
@@ -69,6 +73,7 @@ public class PluginTest {
 
     /**
      * Called before test is run.
+     *
      * @throws Exception thrown
      */
     @Before
@@ -127,10 +132,11 @@ public class PluginTest {
 
     /**
      * Test that building a project generates the intended build messages.
+     *
      * @throws Exception thrown
      */
     @Test
-    public void testBuildProject()  throws Exception {
+    public void testBuildProject() throws Exception {
         String name = "qpwoeiruty";
         DumbSlave slave = j.createOnlineSlave();
         FreeStyleProject project = j.createFreeStyleProject(name);
@@ -145,10 +151,11 @@ public class PluginTest {
 
     /**
      * Test that building two projects generates the intended build messages.
+     *
      * @throws Exception thrown
      */
     @Test
-    public void testBuildProject2()  throws Exception {
+    public void testBuildProject2() throws Exception {
         String name1 = "adsddlfkjgh";
         String name2 = "zmnxbcv";
         DumbSlave slave = j.createOnlineSlave();
@@ -168,6 +175,7 @@ public class PluginTest {
 
     /**
      * Test that building a matrix project generates the intended build messages.
+     *
      * @throws Exception thrown
      */
     @Test
@@ -188,5 +196,22 @@ public class PluginTest {
         assertThat(Mocks.COMPLETED.toString(), containsString(axis2));
     }
 
-}
+    /**
+     * Tests that the publishMQMessage is registered and puts messages in the queue.
+     *
+     * @throws Exception thrown
+     */
+    @Test
+    public void testPipelineStep() throws Exception {
+        MQNotifierConfig config = MQNotifierConfig.getInstance();
+        config.setEnableNotifier(true);
 
+        String message = "{\"key\":\"value\"}";
+
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition("publishMQMessage '" + message + "'", true));
+
+        j.buildAndAssertSuccess(job);
+        assertThat(Mocks.MESSAGES, Matchers.hasItem(message));
+    }
+}


### PR DESCRIPTION
With the introduction of pipeline support various dependencies had
to be updated.

Inlined the dependency versions in pom.xml since the defining them
in a seperate section was unnecessary and messed with IDEAs
autocompletion and validation.

Typical usage:

   publishMQMessage '{"test" : ["value", 1]}'