### PR TITLE
Fix message formatting problem for multi-line parameters

### DIFF
--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
@@ -27,6 +27,8 @@ import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
 import hudson.matrix.MatrixProject;
 import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.TextParameterDefinition;
 import hudson.slaves.DumbSlave;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -214,4 +216,26 @@ public class PluginTest {
         j.buildAndAssertSuccess(job);
         assertThat(Mocks.MESSAGES, Matchers.hasItem(message));
     }
+
+    /**
+     * Ensures that multi-line parameters are represented as a single parameter
+     * in the MQ message.
+     *
+     * @throws Exception thrown
+     */
+    @Test
+    public void testMultilineParameterInMessage() throws Exception {
+        MQNotifierConfig config = MQNotifierConfig.getInstance();
+        config.setEnableNotifier(true);
+
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(
+                new TextParameterDefinition("FOO", "BAR\nBAZ", "Multiline parameter")));
+
+        j.buildAndAssertSuccess(p);
+
+        // Ensure that the parameter is a single entry:
+        assertThat(Mocks.MESSAGES.get(0), containsString("\"FOO=BAR\\nBAZ\""));
+    }
+
 }


### PR DESCRIPTION
If a queued item contained parameters whit values spanning over
multiple lines, then the parameter list in the resulting message was
badly formatted. E.g the parameter FOO='BAR\nBAZ' was encoded as:

parameters:["FOO=BAR","BAZ"]

This change fixes that problem as well as unifying and improving
handling of parameters for queued items and started / completed builds.
This is done by ensuring that it is the same code which produces the
parameters list for all events types.

This change will introduce behavioral changes to the QUEUED messages since the parameters for that message now are printed using parameter.getValue().toString() to print the value instead of parameter.getShortDescription() which was indirectly used through hudson.model.Queue.Item#getParams(). However, I think this minor is outweighed by correct handling.