### PR TITLE
None verbose logging

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -199,10 +199,6 @@ public final class MQConnection implements ShutdownListener {
             bob.contentType(Util.CONTENT_TYPE);
             bob.timestamp(Calendar.getInstance().getTime());
 
-            if(config.isVerboseLoggingEnabled()){
-                LOGGER.debug("Posting JSON message to RabbitMQ:\n" + json.toString(2));
-            }
-
             addMessageToQueue(config.getExchangeName(), config.getRoutingKey(),
                     bob.build(), json.toString().getBytes(StandardCharsets.UTF_8));
         }

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -198,6 +198,11 @@ public final class MQConnection implements ShutdownListener {
             bob.deliveryMode(dm);
             bob.contentType(Util.CONTENT_TYPE);
             bob.timestamp(Calendar.getInstance().getTime());
+
+            if(config.isVerboseLoggingEnabled()){
+                LOGGER.debug("Posting JSON message to RabbitMQ:\n" + json.toString(2));
+            }
+
             addMessageToQueue(config.getExchangeName(), config.getRoutingKey(),
                     bob.build(), json.toString().getBytes(StandardCharsets.UTF_8));
         }

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
@@ -129,7 +129,7 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
     public MQNotifierConfig() {
         this.enableNotifier = false;        // default value
         this.persistentDelivery = true;     // default value
-        this.enableVerboseLogging = false;  // default value
+        this.enableVerboseLogging = true;   // default value
     }
 
     @Override

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
@@ -62,6 +62,9 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
     /* The status whether the plugin is enabled */
     private boolean enableNotifier;
 
+    /* Whether to use verbose logging or not */
+    private boolean enableVerboseLogging;
+
     /* The MQ server URI */
     private String serverUri;
     private String userName;
@@ -85,20 +88,21 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
     /**
      * Creates an instance with specified parameters.
      *
-     * @param enableNotifier     if this plugin is enabled
-     * @param serverUri          the server uri
-     * @param userName           the user name
-     * @param userPassword       the user password
-     * @param exchangeName       the name of the exchange
-     * @param virtualHost        the name of the virtual host
-     * @param routingKey         the routing key
-     * @param persistentDelivery if using persistent delivery mode
-     * @param appId              the application id
+     * @param enableNotifier        if this plugin is enabled
+     * @param serverUri             the server uri
+     * @param userName              the user name
+     * @param userPassword          the user password
+     * @param exchangeName          the name of the exchange
+     * @param virtualHost           the name of the virtual host
+     * @param routingKey            the routing key
+     * @param persistentDelivery    if using persistent delivery mode
+     * @param appId                 the application id
+     * @param enableVerboseLogging  if verbose logging is enabled
      */
     @DataBoundConstructor
     public MQNotifierConfig(boolean enableNotifier, String serverUri, String userName, Secret userPassword,
                             String exchangeName, String virtualHost, String routingKey, boolean persistentDelivery,
-                            String appId) {
+                            String appId, boolean enableVerboseLogging) {
         this.enableNotifier = enableNotifier;
         this.serverUri = serverUri;
         this.userName = userName;
@@ -108,6 +112,7 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
         this.routingKey = routingKey;
         this.persistentDelivery = persistentDelivery;
         this.appId = appId;
+        this.enableVerboseLogging = enableVerboseLogging;
     }
 
     @Override
@@ -122,8 +127,9 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
      * Load configuration on invoke.
      */
     public MQNotifierConfig() {
-        this.enableNotifier = false;    // default value
-        this.persistentDelivery = true; // default value
+        this.enableNotifier = false;        // default value
+        this.persistentDelivery = true;     // default value
+        this.enableVerboseLogging = false;  // default value
     }
 
     @Override
@@ -150,6 +156,24 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
      */
     public void setEnableNotifier(boolean enableNotifier) {
         this.enableNotifier = enableNotifier;
+    }
+
+    /**
+     * Gets whether verbose logging is enabled or not.
+     *
+     * @return true if verbose logging is enabled.
+     */
+    public boolean isVerboseLoggingEnabled() {
+        return this.enableVerboseLogging;
+    }
+
+    /**
+     * Sets flag whether verbose logging is enabled or not.
+     *
+     * @param enableVerboseLogging true if this verbose logging is enabled.
+     */
+    public void setEnableVerboseLogging(boolean enableVerboseLogging) {
+        this.enableVerboseLogging = enableVerboseLogging;
     }
 
     /**

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/RunListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/RunListenerImpl.java
@@ -47,6 +47,13 @@ public class RunListenerImpl extends RunListener<Run> {
         super(Run.class);
     }
 
+    /**
+     * Create a base run message
+     *
+     * @param r the current Jenkins run.
+     * @param state the current state of the Job.
+     * @return JSONObject with base run properties set.
+     */
     private JSONObject createBaseMessage(Run r, String state){
         JSONObject json = new JSONObject();
         json.put(Util.KEY_URL, Util.getJobUrl(r));

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/pipeline/MQMessageStep.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/pipeline/MQMessageStep.java
@@ -24,6 +24,7 @@
 package com.sonymobile.jenkins.plugins.mq.mqnotifier.pipeline;
 
 import com.sonymobile.jenkins.plugins.mq.mqnotifier.MQConnection;
+import com.sonymobile.jenkins.plugins.mq.mqnotifier.MQNotifierConfig;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import net.sf.json.JSONException;
@@ -89,6 +90,7 @@ public class MQMessageStep extends Step {
         @Override
         protected Void run() throws Exception {
             TaskListener listener = getContext().get(TaskListener.class);
+            MQNotifierConfig config = MQNotifierConfig.getInstance();
 
             JSONObject json;
             try {
@@ -102,7 +104,9 @@ public class MQMessageStep extends Step {
             // message is put on a queue to be sent at a later point in time. Preferably we would be able
             // to get a Future<> back so that we could wait if we wanted. But that's not how the MQ
             // Notifier is built.
-            listener.getLogger().println("Posting JSON message to RabbitMQ:\n" + json.toString(2));
+            if(config.isVerboseLoggingEnabled()) {
+                listener.getLogger().println("Posting JSON message to RabbitMQ:\n" + json.toString(2));
+            }
             MQConnection.getInstance().publish(json);
             return null;
         }

--- a/src/main/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig/config.groovy
+++ b/src/main/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig/config.groovy
@@ -59,4 +59,7 @@ f.section(title: "MQ Notifier") {
     f.entry(title: "Persistent Delivery mode", help: l+"help-persistent-delivery.html") {
         f.checkbox(field: "persistentDelivery", checked: my.persistentDelivery)
     }
+    f.entry(title: "Enable verbose logging", help: l+"help-enable-verbose-logging.html") {
+        f.checkbox(field: "enableVerboseLogging", checked: my.enableVerboseLogging)
+    }
 }

--- a/src/main/webapp/help-enable-verbose-logging.html
+++ b/src/main/webapp/help-enable-verbose-logging.html
@@ -1,0 +1,3 @@
+<div>
+    Mark if verbose logging should be enabled. Will e.g. log sent messages, which could be useful while debugging.
+</div>

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
@@ -219,6 +219,29 @@ public class PluginTest {
     }
 
     /**
+     * Test that publishMQMessage correctly logs the custom message when verbose logging is on.
+     *
+     * @throws Exception thrown
+     */
+    @Test
+    public void testPipelineStepLogsMessage() throws Exception {
+        MQNotifierConfig config = MQNotifierConfig.getInstance();
+        config.setEnableNotifier(true);
+        config.setEnableVerboseLogging(true);
+
+        String message = "{\"key\":\"value\"}";
+
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition("publishMQMessage '" + message + "'", true));
+
+        j.buildAndAssertSuccess(job);
+        j.assertLogContains(
+                "Posting JSON message to RabbitMQ:\n{\"key\": \"value\"}",
+                job.getLastCompletedBuild()
+        );
+    }
+
+    /**
      * Ensures that multi-line parameters are represented as a single parameter
      * in the MQ message.
      *

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
@@ -98,6 +98,7 @@ public class PluginTest {
         config.setRoutingKey(ROUTING);
         config.setVirtualHost(null);
         config.setEnableNotifier(false);
+        config.setEnableVerboseLogging(false);
 
         if (config != null && config.isNotifierEnabled()) {
             conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());


### PR DESCRIPTION
The current behavior is that all messages sent in the the pipeline step will be logged in the Jenkins log. This is however sub-optimal, when a lot of messages are sent, as it spams the log. This change adds a verboseLogging option, which people who like the current behavior might use to log all messages sent to RabbitMQ, while the logging could also be turned of.

**Current behavior**

All pipeline messages are written to the log.

 **Desired behavior**

That whether to write MQ messages is conditional.

 **Suggested Solution**

To add a conditional flag (verboseLogging) to enable/disable logging to the Jenkins log.
