### PR TITLE
Feature/durable delivery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,12 @@
       <version>1.12.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>toxiproxy</artifactId>
+      <version>1.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
       <artifactId>commons-validator</artifactId>
       <version>1.7</version>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>rabbitmq</artifactId>
+      <version>1.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
     <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
+    <jmockit.version>1.49</jmockit.version>
   </properties>
 
   <name>MQ Notifier</name>
@@ -90,9 +91,9 @@
       <version>2.22</version>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.jmockit</groupId>
+      <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
-      <version>1.5</version>
+      <version>${jmockit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -223,6 +224,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <argLine>
+            -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+          </argLine>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.37</version>
+    <version>4.3</version>
     <relativePath />
   </parent>
 
@@ -15,7 +15,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.73.3</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
     <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
   </properties>
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.16</version>
+      <version>2.22</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.jmockit</groupId>
@@ -110,23 +110,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.14</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>3.4.1</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-validator</groupId>
-      <artifactId>commons-validator</artifactId>
-      <version>1.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.4</version>
+      <version>5.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -134,11 +123,29 @@
       <version>1.11</version>
     </dependency>
     <dependency>
-      <groupId>commons-digester</groupId>
-      <artifactId>commons-digester</artifactId>
-      <version>2.1</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.11</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <version>1.7</version>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>13</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>
@@ -208,8 +215,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -44,6 +44,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Creates an MQ connection.
@@ -266,6 +267,8 @@ public final class MQConnection implements ShutdownListener {
                 connection.addShutdownListener(this);
             } catch (IOException e) {
                 LOGGER.warn("Connection refused", e);
+            } catch (TimeoutException te) {
+                LOGGER.warn("Attempt to connect timed out: ", te);
             }
         }
         return connection;

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -276,8 +276,11 @@ public final class MQConnection implements ShutdownListener {
     /**
      * Validate the exchange.
      *
+     * @param channel a channel that must contain the given exchange
+     * @param exchange the exchange to validate
+     *
      * @throws IllegalArgumentException if the exchange is null
-     * @throws IOException if the channel exists, but is invalid for the exchange
+     * @throws IOException if the exchange exists, but is invalid for the channel
      */
     private void validateExchange(Channel channel, String exchange) throws IOException, IllegalArgumentException {
         if (exchange == null) {

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -327,7 +327,7 @@ public final class MQConnection implements ShutdownListener {
         // Signature is addConfirmListener(successCallback, errorCallback)
         channel.addConfirmListener(cleanOutstandingConfirms, (sequenceNumber, multiple) -> {
             MessageData message = outstandingConfirms.get(sequenceNumber);
-            messageQueue.add(message);
+            messageQueue.offer(message);
             cleanOutstandingConfirms.handle(sequenceNumber, multiple);
         });
     }
@@ -417,10 +417,10 @@ public final class MQConnection implements ShutdownListener {
                     messageData.getBody()
             );
         } catch (IOException e) {
-            messageQueue.add(messageData);
+            messageQueue.offer(messageData);
             throw new MessageDeliveryException("Cannot publish message", e);
         } catch (AlreadyClosedException e) {
-            messageQueue.add(messageData);
+            messageQueue.offer(messageData);
             throw new MessageDeliveryException("Connection is already closed", e);
         }
     }

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -259,7 +259,7 @@ public final class MQConnection implements ShutdownListener {
                 }
             } catch (InterruptedException ie) {
                 LOGGER.info("sendMessages() poll() was interrupted: ", ie);
-            } catch (IOException ioe) {
+            } catch (IOException | NullPointerException ioe) {
                 LOGGER.error("error validating channel: ", ioe);
             } catch (ChannelCreationException | MessageDeliveryException transientException) {
                 LOGGER.error(transientException.getMessage(), transientException.getCause());
@@ -278,7 +278,7 @@ public final class MQConnection implements ShutdownListener {
      *
      * @throws IOException if the channel is invalid for the exchange
      */
-    private void validateExchange(Channel channel, String exchange) throws IOException {
+    private void validateExchange(Channel channel, String exchange) throws IOException, NullPointerException {
         if (exchange == null) {
             throw new IOException("Invalid configuration, exchange must not be null.");
         }

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -276,7 +276,7 @@ public final class MQConnection implements ShutdownListener {
     /**
      * Validate the exchange.
      *
-     * @throws IllegalArgumentException if the channel is null
+     * @throws IllegalArgumentException if the exchange is null
      * @throws IOException if the channel exists, but is invalid for the exchange
      */
     private void validateExchange(Channel channel, String exchange) throws IOException, IllegalArgumentException {

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -190,6 +190,13 @@ public final class MQConnection implements ShutdownListener {
     }
 
     /**
+     * Clear the outstanding confirms list, useful when testing.
+     */
+    public void clearOutstandingConfirms() {
+        outstandingConfirms.clear();
+    }
+
+    /**
      * Puts a message in the message queue.
      *
      * @param exchange the exchange to publish the message to

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -26,6 +26,7 @@ package com.sonymobile.jenkins.plugins.mq.mqnotifier;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.ConfirmCallback;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.ShutdownListener;
@@ -42,6 +43,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -64,6 +67,7 @@ public final class MQConnection implements ShutdownListener {
     private Connection connection = null;
 
     private volatile LinkedBlockingQueue messageQueue = new LinkedBlockingQueue();
+    private volatile ConcurrentNavigableMap<Long, MessageData> outstandingConfirms = new ConcurrentSkipListMap<>();
     private Thread messageQueueThread;
 
     /* False if messages should not be added to the queue */
@@ -233,6 +237,8 @@ public final class MQConnection implements ShutdownListener {
             try {
                 if (channel == null || !channel.isOpen()) {
                     channel = createChannel();
+                    channel.confirmSelect();
+                    addMessageConfirmListener(channel);
                     setShouldAddToQueue(true);
                 }
                 MessageData messageData = (MessageData) messageQueue.poll(SENDMESSAGE_TIMEOUT,
@@ -307,6 +313,31 @@ public final class MQConnection implements ShutdownListener {
         } catch (IOException | ShutdownSignalException e) {
             throw new ChannelCreationException("Cannot create channel", e);
         }
+    }
+
+    /**
+     * Add an async listener for ack/nack events and remove accordingly.
+     *
+     * @param channel the channel to configure a confirm listener for
+     */
+    private void addMessageConfirmListener(Channel channel) {
+        ConfirmCallback cleanOutstandingConfirms = (sequenceNumber, multiple) -> {
+            if (multiple) {
+                ConcurrentNavigableMap<Long, MessageData> confirmed = this.outstandingConfirms.headMap(
+                        sequenceNumber, true
+                );
+                confirmed.clear();
+            } else {
+                this.outstandingConfirms.remove(sequenceNumber);
+            }
+        };
+
+        // Signature is addConfirmListener(successCallback, errorCallback)
+        channel.addConfirmListener(cleanOutstandingConfirms, (sequenceNumber, multiple) -> {
+            MessageData message = outstandingConfirms.get(sequenceNumber);
+            messageQueue.add(message);
+            cleanOutstandingConfirms.handle(sequenceNumber, multiple);
+        });
     }
 
     /**
@@ -386,6 +417,7 @@ public final class MQConnection implements ShutdownListener {
      */
     private void sendOnChannel(MessageData messageData, Channel channel) throws MessageDeliveryException {
         try {
+            outstandingConfirms.put(channel.getNextPublishSeqNo(), messageData);
             channel.basicPublish(
                     messageData.getExchange(),
                     messageData.getRoutingKey(),

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -86,6 +86,15 @@ public final class MQConnection implements ShutdownListener {
     }
 
     /**
+     * Exception indicating an error delivering a message to MQ
+     */
+    private class MessageDeliveryException extends Exception {
+        public MessageDeliveryException(String errorMessage, Throwable cause) {
+            super(errorMessage, cause);
+        }
+    }
+
+    /**
      * Lazy-loaded singleton using the initialization-on-demand holder pattern.
      */
     private MQConnection() { }
@@ -225,22 +234,23 @@ public final class MQConnection implements ShutdownListener {
 
         while (true) {
             try {
-                if(channel == null || !channel.isOpen()) {
+                if (channel == null || !channel.isOpen()) {
                     channel = createChannel();
+                    setShouldAddToQueue(true);
                 }
                 MessageData messageData = (MessageData) messageQueue.poll(SENDMESSAGE_TIMEOUT,
                                                                          TimeUnit.MILLISECONDS);
                 if (messageData != null) {
                     validateExchange(channel, messageData.getExchange());
-                    getInstance().sendOnChannel(messageData.getExchange(), messageData.getRoutingKey(),
-                            messageData.getProps(), messageData.getBody(), channel);
+                    getInstance().sendOnChannel(messageData, channel);
                 }
             } catch (InterruptedException ie) {
                 LOGGER.info("sendMessages() poll() was interrupted: ", ie);
             } catch (IOException ioe) {
                 LOGGER.error("error validating channel: ", ioe);
-            } catch (ChannelCreationException cce) {
-                LOGGER.error(cce.getMessage(), cce.getCause());
+            } catch (ChannelCreationException | MessageDeliveryException transientException) {
+                LOGGER.error(transientException.getMessage(), transientException.getCause());
+                setShouldAddToQueue(false);
                 try {
                     Thread.sleep(CONNECTION_WAIT);
                 } catch (InterruptedException ie) {
@@ -294,7 +304,6 @@ public final class MQConnection implements ShutdownListener {
             connection = getConnection();
             if (connection != null) {
                 LOGGER.debug("Channel successfully created");
-                setShouldAddToQueue(true);
                 return connection.createChannel();
             }
             throw new ChannelCreationException("Cannot create channel, no connection found");
@@ -375,19 +384,23 @@ public final class MQConnection implements ShutdownListener {
      * Sends a message.
      * Keeps trying to get a connection indefinitely.
      *
-     * @param exchange the exchange to publish the message to
-     * @param routingKey the routing key
-     * @param props other properties for the message - routing headers etc
-     * @param body the message body
+     * @param messageData an object containing message data
+     * @param channel a channel to publish the message on
      */
-    private void sendOnChannel(String exchange, String routingKey, AMQP.BasicProperties props, byte[] body,
-                               Channel channel) {
+    private void sendOnChannel(MessageData messageData, Channel channel) throws MessageDeliveryException {
         try {
-            channel.basicPublish(exchange, routingKey, props, body);
+            channel.basicPublish(
+                    messageData.getExchange(),
+                    messageData.getRoutingKey(),
+                    messageData.getProps(),
+                    messageData.getBody()
+            );
         } catch (IOException e) {
-            LOGGER.error("Cannot publish message", e);
+            messageQueue.add(messageData);
+            throw new MessageDeliveryException("Cannot publish message", e);
         } catch (AlreadyClosedException e) {
-            LOGGER.error("Connection is already closed", e);
+            messageQueue.add(messageData);
+            throw new MessageDeliveryException("Connection is already closed", e);
         }
     }
 

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -66,12 +66,9 @@ public final class MQConnection implements ShutdownListener {
     private String virtualHost;
     private Connection connection = null;
 
-    private volatile LinkedBlockingQueue messageQueue = new LinkedBlockingQueue(10000);
+    private volatile LinkedBlockingQueue messageQueue = new LinkedBlockingQueue(100000);
     private volatile ConcurrentNavigableMap<Long, MessageData> outstandingConfirms = new ConcurrentSkipListMap<>();
     private Thread messageQueueThread;
-
-    /* False if messages should not be added to the queue */
-    private volatile boolean shouldAddToQueue = false;
 
 
     /**

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -181,6 +181,15 @@ public final class MQConnection implements ShutdownListener {
     }
 
     /**
+     * Get the number of currently outstanding confirms
+     *
+     * @return the number of currently outstanding confirms
+     */
+    public int getSizeOutstandingConfirms() {
+        return outstandingConfirms.size();
+    }
+
+    /**
      * Puts a message in the message queue.
      *
      * @param exchange the exchange to publish the message to

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -54,7 +54,6 @@ import java.util.concurrent.TimeoutException;
 public final class MQConnection implements ShutdownListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(MQConnection.class);
     private static final int HEARTBEAT_INTERVAL = 30;
-    private static final int MESSAGE_QUEUE_SIZE = 1000;
     private static final int SENDMESSAGE_TIMEOUT = 100;
     private static final int CONNECTION_WAIT = 10000;
 
@@ -64,7 +63,7 @@ public final class MQConnection implements ShutdownListener {
     private String virtualHost;
     private Connection connection = null;
 
-    private volatile LinkedBlockingQueue messageQueue = new LinkedBlockingQueue(MESSAGE_QUEUE_SIZE);
+    private volatile LinkedBlockingQueue messageQueue = new LinkedBlockingQueue();
     private Thread messageQueueThread;
 
     /* False if messages should not be added to the queue */
@@ -199,9 +198,7 @@ public final class MQConnection implements ShutdownListener {
 
         MessageData messageData = new MessageData(exchange, routingKey, props, body);
         waitForQueue(); // Block execution until queue is available
-        if (!messageQueue.offer(messageData)) {
-            LOGGER.error("addMessageToQueue() failed, RabbitMQ queue is full!");
-        }
+        messageQueue.offer(messageData);
     }
 
     /**

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
@@ -55,7 +55,7 @@ public class ConnectionIntegrationTest {
     }
 
     /**
-     * Creates a connection to rabbitMQ (through toxiproxy) and configure exchanges, passwords etc.
+     * Creates a connection to RabbitMQ through toxiproxy and configures exchanges, passwords etc.
      */
     @Before
     public void createProxyConnection() {
@@ -69,7 +69,7 @@ public class ConnectionIntegrationTest {
     }
 
     /**
-     * Format an uri to the toxiproxy.
+     * Format an URI to toxiproxy, which will be forwarded to RabbitMQ.
      */
     private String formatProxyServerUri() {
         ToxiproxyContainer.ContainerProxy proxy = getProxy();
@@ -104,7 +104,7 @@ public class ConnectionIntegrationTest {
         });
         Thread.sleep(1000);
         getProxy().setConnectionCut(false);
-        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 1000, 20, TestUtil.QUEUE_NAME);
+        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 1000, 10, TestUtil.QUEUE_NAME);
         assertEquals(expectedMessages, actualMessages);
     }
 
@@ -112,7 +112,7 @@ public class ConnectionIntegrationTest {
      * Test that the MQNotifier won't lose messages when upstream is closed, i.e. no acks.
      */
     @Test
-    public void testSendMessagesHandlesUpstremTimeout() throws InterruptedException, IOException {
+    public void testSendMessagesHandlesUpstreamTimeout() throws InterruptedException, IOException {
         MQConnection conn = MQConnection.getInstance();
         ArrayList<JSONObject> expectedMessages = TestUtil.createMessages(1000);
         getProxy().toxics().timeout("timeout", ToxicDirection.UPSTREAM, 8000);
@@ -121,7 +121,7 @@ public class ConnectionIntegrationTest {
         });
         Thread.sleep(8000);
         getProxy().toxics().get("timeout", Timeout.class).remove();
-        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 1000, 20, TestUtil.QUEUE_NAME);
+        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 1000, 10, TestUtil.QUEUE_NAME);
         assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }
@@ -146,8 +146,7 @@ public class ConnectionIntegrationTest {
         getProxy().setConnectionCut(true);
         Thread.sleep(5000);
         getProxy().setConnectionCut(false);
-        System.out.println("Start waiting");
-        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 1000, 30, TestUtil.QUEUE_NAME);
+        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 1000, 10, TestUtil.QUEUE_NAME);
         assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }
@@ -163,7 +162,7 @@ public class ConnectionIntegrationTest {
         executor.submit(() -> {
             expectedMessages.forEach(conn::publish);
         });
-        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 3, 50, TestUtil.QUEUE_NAME);
+        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 3, 10, TestUtil.QUEUE_NAME);
         assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
@@ -69,6 +69,14 @@ public class ConnectionIntegrationTest {
     }
 
     /**
+     * Clean up outstanding messages before running new tests.
+     */
+    @Before
+    public void clearOutstandingConfirms() {
+        MQConnection.getInstance().clearOutstandingConfirms();
+    }
+
+    /**
      * Format an URI to toxiproxy, which will be forwarded to RabbitMQ.
      */
     private String formatProxyServerUri() {
@@ -88,6 +96,7 @@ public class ConnectionIntegrationTest {
         expectedMessages.forEach(conn::publish);
         ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 10, 10, TestUtil.QUEUE_NAME);
         assertEquals(expectedMessages, actualMessages);
+        assertEquals( 0, conn.getSizeOutstandingConfirms());
     }
 
     /**
@@ -105,6 +114,7 @@ public class ConnectionIntegrationTest {
         Thread.sleep(1000);
         getProxy().setConnectionCut(false);
         ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 1000, 10, TestUtil.QUEUE_NAME);
+        assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }
 
@@ -162,7 +172,7 @@ public class ConnectionIntegrationTest {
         executor.submit(() -> {
             expectedMessages.forEach(conn::publish);
         });
-        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 3, 10, TestUtil.QUEUE_NAME);
+        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 3, 20, TestUtil.QUEUE_NAME);
         assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
@@ -1,15 +1,25 @@
 package com.sonymobile.jenkins.plugins.mq.mqnotifier;
 
 import net.sf.json.JSONObject;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.testcontainers.containers.Network.newNetwork;
+
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -21,29 +31,82 @@ import static org.junit.Assert.assertNotNull;
  */
 public class ConnectionIntegrationTest {
 
+    private static final String TOXIPROXY_NETWORK_ALIAS = "toxiproxy";
+
     RabbitMQContainer defaultMQContainer = TestUtil.getDefaultMQContainer();
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @Rule
+    public Network network = newNetwork();
+
+    public ToxiproxyContainer toxiproxy = new ToxiproxyContainer()
+            .withNetwork(network)
+            .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS);
 
     @Rule
     public TestRule chain = RuleChain
-            .outerRule(defaultMQContainer)
+            .outerRule(defaultMQContainer.withNetwork(network))
+            .around(toxiproxy)
             .around(new JenkinsRule());
+
+    /**
+     * Get the toxiproxy for the MQ container
+     */
+    private ToxiproxyContainer.ContainerProxy getProxy() {
+        return toxiproxy.getProxy(defaultMQContainer, TestUtil.PORT);
+    }
+
+    /**
+     * Creates a connection to rabbitMQ (through toxiproxy) and configure exchanges, passwords etc.
+     */
+    @Before
+    public void createProxyConnection() {
+        MQNotifierConfig config = MQNotifierConfig.getInstance();
+        assertNotNull("No config available: MQNotifierConfig", config);
+        TestUtil.setDefaultConfig(config);
+        config.setServerUri(formatProxyServerUri());
+
+        MQConnection conn = MQConnection.getInstance();
+        conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
+    }
+
+    /**
+     * Format an uri to the toxiproxy.
+     */
+    private String formatProxyServerUri() {
+        ToxiproxyContainer.ContainerProxy proxy = getProxy();
+        final String ipAddressViaToxiproxy = proxy.getContainerIpAddress();
+        final int portViaToxiproxy = proxy.getProxyPort();
+        return "amqp://" + ipAddressViaToxiproxy + ":" + portViaToxiproxy;
+    }
 
     /**
      * Test that the MQNotifier plugin sends messages correctly.
      */
     @Test
     public void testSentMessagesHasCorrectFormat() throws IOException, InterruptedException {
-        MQNotifierConfig config = MQNotifierConfig.getInstance();
-        assertNotNull("No config available: MQNotifierConfig", config);
-        TestUtil.setDefaultConfig(config);
-        config.setServerUri(defaultMQContainer.getAmqpUrl());
-
         MQConnection conn = MQConnection.getInstance();
-        conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
-
         ArrayList<JSONObject> expectedMessages = TestUtil.createMessages(10);
-        TestUtil.sendMessagesWithinTimeframe(expectedMessages, conn, 10);
+        expectedMessages.forEach(conn::publish);
         ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 10, 10, TestUtil.QUEUE_NAME);
+        assertEquals(expectedMessages, actualMessages);
+    }
+
+    /**
+     * Test that the MQNotifier won't lose messages when the connection is closed.
+     */
+    @Test
+    public void testSendMessagesHandlesClosedConnection() throws InterruptedException, IOException {
+        MQConnection conn = MQConnection.getInstance();
+        ArrayList<JSONObject> expectedMessages = TestUtil.createMessages(1000);
+
+        getProxy().setConnectionCut(true);
+        executor.submit(() -> {
+            expectedMessages.forEach(conn::publish);
+        });
+        Thread.sleep(1000);
+        getProxy().setConnectionCut(false);
+        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 1000, 40, TestUtil.QUEUE_NAME);
         assertEquals(expectedMessages, actualMessages);
     }
 

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.sonymobile.jenkins.plugins.mq.mqnotifier;
+
+import net.sf.json.JSONObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.testcontainers.containers.RabbitMQContainer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Integration tests for the MQConnection
+ *
+ * @author Hampus Johansson
+ */
+public class ConnectionIntegrationTest {
+
+    RabbitMQContainer defaultMQContainer = TestUtil.getDefaultMQContainer();
+
+    @Rule
+    public TestRule chain = RuleChain
+            .outerRule(defaultMQContainer)
+            .around(new JenkinsRule());
+
+    /**
+     * Test that the MQNotifier plugin sends messages correctly.
+     */
+    @Test
+    public void testSentMessagesHasCorrectFormat() throws IOException, InterruptedException {
+        MQNotifierConfig config = MQNotifierConfig.getInstance();
+        assertNotNull("No config available: MQNotifierConfig", config);
+        TestUtil.setDefaultConfig(config);
+        config.setServerUri(defaultMQContainer.getAmqpUrl());
+
+        MQConnection conn = MQConnection.getInstance();
+        conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
+
+        ArrayList<JSONObject> expectedMessages = TestUtil.createMessages(10);
+        TestUtil.sendMessagesWithinTimeframe(expectedMessages, conn, 10);
+        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 10, 10, TestUtil.QUEUE_NAME);
+        assertEquals(expectedMessages, actualMessages);
+    }
+
+}

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
@@ -172,7 +172,7 @@ public class ConnectionIntegrationTest {
         executor.submit(() -> {
             expectedMessages.forEach(conn::publish);
         });
-        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 3, 20, TestUtil.QUEUE_NAME);
+        ArrayList<JSONObject> actualMessages = TestUtil.waitForMessages(conn, 3, 30, TestUtil.QUEUE_NAME);
         assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/TestUtil.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/TestUtil.java
@@ -33,7 +33,7 @@ public final class TestUtil {
      * with a binding to a queue (QUEUE_NAME). No routing queue should be specified. The container may
      * be started by, for example, using a jUnit @Rule.
      *
-     * @return an RabbitMQ container singleton. The container is not started.
+     * @return an RabbitMQ container singleton. A container is not started.
      */
     public static RabbitMQContainer getDefaultMQContainer() {
         if (defaultMQContainer == null) {
@@ -65,16 +65,16 @@ public final class TestUtil {
      * Wait for x messages on the queue to be published.
      *
      * @param conn A connection to be used for connecting to RabbitMQ
-     * @param stopAtMessage stop after finding this many messages
-     * @param maxWaitTime the max time to wait for a message
+     * @param numberExpectedMessages stop after finding this many messages
+     * @param secondsWaitPerMessage the max time to wait for a message
      * @param queueName the queue to listen to messages on
      *
      * @return a list of the found messages as JSONObjects
      */
     public static ArrayList<JSONObject> waitForMessages(
             MQConnection conn,
-            int stopAtMessage,
-            int maxWaitTime,
+            int numberExpectedMessages,
+            int secondsWaitPerMessage,
             String queueName
     ) throws IOException, InterruptedException {
         Channel channel = null;
@@ -107,8 +107,8 @@ public final class TestUtil {
         channel.basicConsume(queueName, true, consumer);
 
         synchronized (foundMessages) {
-            while(foundMessages.size() != stopAtMessage) {
-                foundMessages.wait(Duration.ofSeconds(maxWaitTime).toMillis());
+            while(foundMessages.size() != numberExpectedMessages) {
+                foundMessages.wait(Duration.ofSeconds(secondsWaitPerMessage).toMillis());
             }
             foundMessages.drainTo(foundMessagesArray);
         }
@@ -118,12 +118,12 @@ public final class TestUtil {
     /**
      * Creates a list of x messages. Useful for generating messages during testing.
      *
-     * @param numberOfMessages the number of messages to create
+     * @param count the number of messages to create
      *
      * @return list of messages
      */
-    public static ArrayList<JSONObject> createMessages(int numberOfMessages) {
-        return IntStream.range(1, numberOfMessages+1).mapToObj(i -> {
+    public static ArrayList<JSONObject> createMessages(int count) {
+        return IntStream.range(1, count+1).mapToObj(i -> {
             JSONObject message = new JSONObject();
             message.put("test", "test" + i);
             return message;

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/TestUtil.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/TestUtil.java
@@ -6,15 +6,12 @@ import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import hudson.util.Secret;
 import net.sf.json.JSONObject;
-import org.junit.AssumptionViolatedException;
 import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.containers.ToxiproxyContainer;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/TestUtil.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/TestUtil.java
@@ -1,0 +1,162 @@
+package com.sonymobile.jenkins.plugins.mq.mqnotifier;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import hudson.util.Secret;
+import net.sf.json.JSONObject;
+import org.junit.AssumptionViolatedException;
+import org.testcontainers.containers.RabbitMQContainer;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Utility methods for running e.g. integration tests and configuration setup.
+ *
+ * @author Hampus Johansson
+ */
+public final class TestUtil {
+
+    public static final String EXCHANGE = "jenkins";
+    public static final String QUEUE_NAME = "test-queue";
+    public static final int PORT = 5672;
+
+    private static RabbitMQContainer defaultMQContainer = null;
+
+    /**
+     * Creates a default RabbitMQ container to run tests against. It declares an Exchange (EXCHANGE)
+     * with a binding to a queue (QUEUE_NAME). No routing queue should be specified. The container may
+     * be started by, for example, using a jUnit @Rule.
+     *
+     * @return an RabbitMQ container singleton. The container is not started.
+     */
+    public static RabbitMQContainer getDefaultMQContainer() {
+        if (defaultMQContainer == null) {
+            defaultMQContainer = new RabbitMQContainer("rabbitmq:3-management")
+                    .withExposedPorts(PORT)
+                    .withExposedPorts(15672)
+                    .withExchange(EXCHANGE, "direct")
+                    .withQueue(QUEUE_NAME)
+                    .withBinding(EXCHANGE, QUEUE_NAME);
+        }
+        return defaultMQContainer;
+    }
+
+    /**
+     * Set common configuration values, intended for use together with the RabbitMQ container.
+     *
+     * @param config A configuration object to set default configuration for.
+     */
+    public static void setDefaultConfig(MQNotifierConfig config) {
+        config.setUserName("guest");
+        config.setUserPassword(Secret.fromString("guest"));
+        config.setExchangeName(EXCHANGE);
+        config.setRoutingKey("");
+        config.setVirtualHost(null);
+        config.setEnableNotifier(true);
+    }
+
+    /**
+     * Wait for x messages on the queue to be published.
+     *
+     * @param conn A connection to be used for connecting to RabbitMQ
+     * @param stopAtMessage stop after finding this many messages
+     * @param maxWaitTime the max time to wait for a message
+     * @param queueName the queue to listen to messages on
+     *
+     * @return a list of the found messages as JSONObjects
+     */
+    public static ArrayList<JSONObject> waitForMessages(
+            MQConnection conn,
+            int stopAtMessage,
+            int maxWaitTime,
+            String queueName
+    ) throws IOException, InterruptedException {
+        Channel channel = conn.getConnection().openChannel().get();
+        LinkedBlockingQueue<JSONObject> foundMessages = new LinkedBlockingQueue<>();
+        ArrayList<JSONObject> foundMessagesArray = new ArrayList<>();
+
+        DefaultConsumer consumer = new DefaultConsumer(channel) {
+            @Override
+            public void handleDelivery(
+                    String consumerTag,
+                    Envelope envelope,
+                    AMQP.BasicProperties properties,
+                    byte[] body) throws IOException {
+
+                JSONObject message = JSONObject.fromObject(new String(body));
+                foundMessages.offer(message);
+                synchronized (foundMessages) {
+                    foundMessages.notify();
+                }
+            }
+        };
+
+        channel.basicConsume(queueName, true, consumer);
+
+        synchronized (foundMessages) {
+            while(foundMessages.size() != stopAtMessage) {
+                foundMessages.wait(Duration.ofSeconds(maxWaitTime).toMillis());
+            }
+            foundMessages.drainTo(foundMessagesArray);
+        }
+        return foundMessagesArray;
+    }
+
+    /**
+     * Publish a list of messages to RabbitMQ.
+     *
+     * @param messages the messages, as JSONObjects to be published to RabbitMQ
+     * @param conn A connection to be used for connecting to RabbitMQ and to publish messages on
+     * @param waitTime the max time to wait for all messages to be published
+     *
+     * @throws InterruptedException if all messages couldn't be publish within the wait time
+     */
+    public static void sendMessagesWithinTimeframe(ArrayList<JSONObject> messages, MQConnection conn, int waitTime) throws InterruptedException {
+        messages.forEach(conn::publish);
+        if (!waitUntil(Duration.ofSeconds(waitTime), () -> conn.getSizeOutstandingConfirms() == 0)) {
+            throw new AssumptionViolatedException("All messages could not be confirmed within the timeframe");
+        }
+    }
+
+    /**
+     * Creates a list of x messages. Useful for generating messages during testing.
+     *
+     * @param numberOfMessages the number of messages to create
+     *
+     * @return list of messages
+     */
+    public static ArrayList<JSONObject> createMessages(int numberOfMessages) {
+        return IntStream.range(1, numberOfMessages+1).mapToObj(i -> {
+            JSONObject message = new JSONObject();
+            message.put("test", "test" + i);
+            return message;
+        }).collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Busy wait until a condition becomes true
+     *
+     * @param timeout a timeout not to wait longer than.
+     * @param condition a condition to evaluate. Proceed if condition is true
+     *
+     * @return the return value of the condition
+     * @throws InterruptedException if the sleep is interrupted
+     */
+    public static boolean waitUntil(Duration timeout, BooleanSupplier condition) throws InterruptedException {
+        int waited = 0;
+        while (!condition.getAsBoolean() && waited < timeout.toMillis()) {
+            Thread.sleep(100L);
+            waited += 100;
+        }
+        return condition.getAsBoolean();
+    }
+
+}


### PR DESCRIPTION
There are some issues related to the durability of the MQNotifier plugin. This pull request is intended to fix those problems.

### Current Behavior

- The RabbitMQ notifier do not confirm that messages were delivered. This is problematic, since a drop of the connection could lead to dropping messages. 

- When the fixed size queue overflows, for example, due to a RabbitMQ outage, the messages are dropped. I have observed thousands of messages being dropped, in production, on RabbitMQ outages.

### Desired Behavior

- The RabbitMQ notifier should confirm that messages are delivered and retry if they aren't. 

- The RabbitMQ should block, i.e. apply backpressure, when no connection to RabbitMQ is present. 

### Solution

The following changes have been implemented in this patchset:

-  Async ack/nack behaviour has been added, as [suggested by the RabbitMQ team](https://www.rabbitmq.com/tutorials/tutorial-seven-java.html).

- Updated Jenkins LTS, plugin master and pipeline dependencies to be able to upgrade the RabbitMQ client to a version supporting async ack/nack.

- Added a flag to decide whether to add messages to the queue or not. When the connection is down we will pause adding to queue, which will block the main thread.

- Removed synchronized, which is already handled by LinkedBlockingQueue.

- Added testcontainers for [RabbitMQ](https://www.testcontainers.org/modules/rabbitmq/) and [toxiproxy](https://www.testcontainers.org/modules/toxiproxy/) to be able to run integration tests.

- Added integration tests to test the durability of the connection. Tested some "chaos" scenarios, to validate durability.

- Improved error handling.