### PR TITLE
Make exceptions static

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -75,7 +75,7 @@ public final class MQConnection implements ShutdownListener {
     /**
      * Throw on exceptions when creating a channel
      */
-    private class ChannelCreationException extends IOException {
+    private static class ChannelCreationException extends IOException {
 
         public ChannelCreationException(String errorMessage) {
             super(errorMessage);
@@ -89,7 +89,7 @@ public final class MQConnection implements ShutdownListener {
     /**
      * Exception indicating an error delivering a message to MQ
      */
-    private class MessageDeliveryException extends IOException {
+    private static class MessageDeliveryException extends IOException {
         public MessageDeliveryException(String errorMessage, Throwable cause) {
             super(errorMessage, cause);
         }


### PR DESCRIPTION
Inner classes should be static in case they are referenced from outside the MQConnection class.