### PR TITLE
Feature/configuration as code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.3</version>
+    <version>4.19</version>
     <relativePath />
   </parent>
 
@@ -17,7 +17,7 @@
   <properties>
     <jenkins.version>2.318</jenkins.version>
     <java.level>8</java.level>
-    <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.71</jenkins-test-harness.version>
     <jmockit.version>1.49</jmockit.version>
   </properties>
 
@@ -168,6 +168,16 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>toxiproxy</artifactId>
       <version>1.15.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ItemListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ItemListenerImpl.java
@@ -50,7 +50,7 @@ public class ItemListenerImpl extends ItemListener {
     public final void onLoaded() {
         LOGGER.info("All jobs have been loaded.");
         MQNotifierConfig config = MQNotifierConfig.getInstance();
-        if (config != null && config.isNotifierEnabled()) {
+        if (config != null && config.getEnableNotifier()) {
             MQConnection.getInstance().initialize(config.getUserName(), config.getUserPassword(),
                     config.getServerUri(), config.getVirtualHost());
         }

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQConnection.java
@@ -224,7 +224,7 @@ public final class MQConnection implements ShutdownListener {
      */
     public void publish(JSONObject json) {
         MQNotifierConfig config = MQNotifierConfig.getInstance();
-        if (config != null && config.isNotifierEnabled()) {
+        if (config != null && config.getEnableNotifier()) {
             AMQP.BasicProperties.Builder bob = new AMQP.BasicProperties.Builder();
             int dm = 1;
             if (config.getPersistentDelivery()) {

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
@@ -26,15 +26,15 @@ package com.sonymobile.jenkins.plugins.mq.mqnotifier;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.PossibleAuthenticationFailureException;
 import hudson.Extension;
-import hudson.Plugin;
-import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.UrlValidator;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -43,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
-import java.io.IOException;
 import java.net.URISyntaxException;
 
 /**
@@ -52,7 +51,8 @@ import java.net.URISyntaxException;
  * @author Örjan Percy &lt;orjan.percy@sonymobile.com&gt;
  */
 @Extension
-public final class MQNotifierConfig extends Plugin implements Describable<MQNotifierConfig> {
+@Symbol("mqNotifier")
+public final class MQNotifierConfig extends GlobalConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(MQNotifierConfig.class);
     private final String[] schemes = {"amqp", "amqps"};
     private static final String SERVER_URI = "serverUri";
@@ -115,14 +115,6 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
         this.enableVerboseLogging = enableVerboseLogging;
     }
 
-    @Override
-    public void start() throws Exception {
-        super.start();
-        LOGGER.info("Starting MQNotifier Plugin");
-        load();
-        MQConnection.getInstance().initialize(userName, userPassword, serverUri, virtualHost);
-    }
-
     /**
      * Load configuration on invoke.
      */
@@ -133,11 +125,11 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
     }
 
     @Override
-    public void configure(StaplerRequest req, JSONObject formData) throws IOException, ServletException,
-            Descriptor.FormException {
+    public boolean configure(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
         req.bindJSON(this, formData);
         save();
         MQConnection.getInstance().initialize(userName, userPassword, serverUri, virtualHost);
+        return true;
     }
 
     /**
@@ -145,7 +137,7 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
      *
      * @return true if this plugin is enabled.
      */
-    public boolean isNotifierEnabled() {
+    public boolean getEnableNotifier() {
         return this.enableNotifier;
     }
 
@@ -163,7 +155,7 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
      *
      * @return true if verbose logging is enabled.
      */
-    public boolean isVerboseLoggingEnabled() {
+    public boolean getEnableVerboseLogging() {
         return this.enableVerboseLogging;
     }
 
@@ -239,13 +231,7 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
      * @return the instance of this extension.
      */
     public static MQNotifierConfig getInstance() {
-        Jenkins jenkins = Jenkins.getInstance();
-        if (jenkins != null) {
-            return jenkins.getPlugin(MQNotifierConfig.class);
-        } else {
-            LOGGER.error("Error, Jenkins could not be found, so no plugin!");
-            return null;
-        }
+        return MQNotifierConfig.all().get(MQNotifierConfig.class);
     }
 
     /**
@@ -338,66 +324,50 @@ public final class MQNotifierConfig extends Plugin implements Describable<MQNoti
         this.appId = appId;
     }
 
-
-    /**
-     * Returns the descriptor instance.
-     *
-     * @return descriptor instance.
-     */
     @Override
-    public Descriptor<MQNotifierConfig> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+    public String getDisplayName() {
+        return "MQ Notifier Plugin";
     }
 
     /**
-     * Implementation of the Descriptor interface.
+     * Tests connection to the server URI.
+     *
+     * @param uri the URI.
+     * @param name the user name.
+     * @param pw the user password.
+     * @return FormValidation object that indicates ok or error.
+     * @throws javax.servlet.ServletException Exception for servlet.
      */
-    @Extension
-    public static final class DescriptorImpl extends Descriptor<MQNotifierConfig> {
-        @Override
-        public String getDisplayName() {
-            return "MQ Notifier Plugin";
-        }
-
-        /**
-         * Tests connection to the server URI.
-         *
-         * @param uri the URI.
-         * @param name the user name.
-         * @param pw the user password.
-         * @return FormValidation object that indicates ok or error.
-         * @throws javax.servlet.ServletException Exception for servlet.
-         */
-        @RequirePOST
-        public FormValidation doTestConnection(@QueryParameter(SERVER_URI) final String uri,
-                                               @QueryParameter(USERNAME) final String name,
-                                               @QueryParameter(PASSWORD) final Secret pw) throws ServletException {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-            UrlValidator urlValidator = new UrlValidator(getInstance().schemes, UrlValidator.ALLOW_LOCAL_URLS);
-            FormValidation result = FormValidation.ok();
-            if (urlValidator.isValid(uri)) {
-                try {
-                    ConnectionFactory conn = new ConnectionFactory();
-                    conn.setUri(uri);
-                    if (StringUtils.isNotEmpty(name)) {
-                        conn.setUsername(name);
-                        if (StringUtils.isNotEmpty(Secret.toString(pw))) {
-                            conn.setPassword(Secret.toString(pw));
-                        }
+    @RequirePOST
+    public FormValidation doTestConnection(@QueryParameter(SERVER_URI) final String uri,
+                                           @QueryParameter(USERNAME) final String name,
+                                           @QueryParameter(PASSWORD) final Secret pw) throws ServletException {
+        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        UrlValidator urlValidator = new UrlValidator(getInstance().schemes, UrlValidator.ALLOW_LOCAL_URLS);
+        FormValidation result = FormValidation.ok();
+        if (urlValidator.isValid(uri)) {
+            try {
+                ConnectionFactory conn = new ConnectionFactory();
+                conn.setUri(uri);
+                if (StringUtils.isNotEmpty(name)) {
+                    conn.setUsername(name);
+                    if (StringUtils.isNotEmpty(Secret.toString(pw))) {
+                        conn.setPassword(Secret.toString(pw));
                     }
-                    conn.newConnection();
-                } catch (URISyntaxException e) {
-                    result = FormValidation.error("Invalid Uri");
-                } catch (PossibleAuthenticationFailureException e) {
-                    result = FormValidation.error("Authentication Failure");
-                } catch (Exception e) {
-                    result = FormValidation.error(e.getMessage());
                 }
-            } else {
+                conn.newConnection();
+            } catch (URISyntaxException e) {
                 result = FormValidation.error("Invalid Uri");
+            } catch (PossibleAuthenticationFailureException e) {
+                result = FormValidation.error("Authentication Failure");
+            } catch (Exception e) {
+                result = FormValidation.error(e.getMessage());
             }
-            return result;
+        } else {
+            result = FormValidation.error("Invalid Uri");
         }
+        return result;
+
     }
 
 }

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
@@ -51,7 +51,7 @@ import java.net.URISyntaxException;
  * @author Örjan Percy &lt;orjan.percy@sonymobile.com&gt;
  */
 @Extension
-@Symbol("mqNotifier")
+@Symbol("mq-notifier")
 public final class MQNotifierConfig extends GlobalConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(MQNotifierConfig.class);
     private final String[] schemes = {"amqp", "amqps"};

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig.java
@@ -26,6 +26,7 @@ package com.sonymobile.jenkins.plugins.mq.mqnotifier;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.PossibleAuthenticationFailureException;
 import hudson.Extension;
+import hudson.XmlFile;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
@@ -42,8 +43,9 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletException;
+import java.io.File;
 import java.net.URISyntaxException;
+import javax.servlet.ServletException;
 
 /**
  * Adds the MQ notifier plugin configuration to the system config page.
@@ -58,6 +60,9 @@ public final class MQNotifierConfig extends GlobalConfiguration {
     private static final String SERVER_URI = "serverUri";
     private static final String USERNAME = "userName";
     private static final String PASSWORD = "userPassword";
+
+    /* The name of the configuration file. */
+    private static final String CONFIG_XML = "mq-notifier.xml";
 
     /* The status whether the plugin is enabled */
     private boolean enableNotifier;
@@ -113,6 +118,7 @@ public final class MQNotifierConfig extends GlobalConfiguration {
         this.persistentDelivery = persistentDelivery;
         this.appId = appId;
         this.enableVerboseLogging = enableVerboseLogging;
+        super.load();
     }
 
     /**
@@ -122,6 +128,7 @@ public final class MQNotifierConfig extends GlobalConfiguration {
         this.enableNotifier = false;        // default value
         this.persistentDelivery = true;     // default value
         this.enableVerboseLogging = true;   // default value
+        super.load();
     }
 
     @Override
@@ -131,6 +138,17 @@ public final class MQNotifierConfig extends GlobalConfiguration {
         MQConnection.getInstance().initialize(userName, userPassword, serverUri, virtualHost);
         return true;
     }
+
+    /**
+     * For backwards-compatibility with the previous Plugin derived version.
+     *
+     * @return XmlFile representing the ConfigFile.
+     */
+    @Override
+    protected XmlFile getConfigFile() {
+        return new XmlFile(new File(Jenkins.get().getRootDir(), CONFIG_XML));
+    }
+
 
     /**
      * Gets whether this plugin is enabled or not.

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/RunListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/RunListenerImpl.java
@@ -50,7 +50,7 @@ public class RunListenerImpl extends RunListener<Run> {
     private  MQNotifierConfig config = MQNotifierConfig.getInstance();
 
     private void logMessage(JSONObject message, TaskListener listener) {
-        if (this.config.isVerboseLoggingEnabled()) {
+        if (this.config.getEnableVerboseLogging()) {
             listener.getLogger().println("Posting JSON message to RabbitMQ:\n" + message.toString(2));
         }
     }

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/pipeline/MQMessageStep.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/pipeline/MQMessageStep.java
@@ -104,7 +104,7 @@ public class MQMessageStep extends Step {
             // message is put on a queue to be sent at a later point in time. Preferably we would be able
             // to get a Future<> back so that we could wait if we wanted. But that's not how the MQ
             // Notifier is built.
-            if (config.isVerboseLoggingEnabled()) {
+            if (config.getEnableVerboseLogging()) {
                 listener.getLogger().println("Posting JSON message to RabbitMQ:\n" + json.toString(2));
             }
             MQConnection.getInstance().publish(json);

--- a/src/main/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig/config.groovy
+++ b/src/main/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/MQNotifierConfig/config.groovy
@@ -29,37 +29,37 @@ def l = "/plugin/mq-notifier/"
 f.section(title: "MQ Notifier") {
 
     f.entry(title: "Enable Notifier", help: l+"help-enable-notifier.html") {
-        f.checkbox(field: "enableNotifier", checked: my.enableNotifier)
+        f.checkbox(field: "enableNotifier", checked: instance.enableNotifier)
     }
     f.entry(title: "MQ URI", field: "serverUri", help: l+"help-amqp-uri.html") {
-        f.textbox("value":my.serverUri)
+        f.textbox("value":instance.serverUri)
     }
     f.entry(title: "User name", field: "userName", help: l+"help-user-name.html") {
-        f.textbox("value":my.userName)
+        f.textbox("value":instance.userName)
     }
     f.entry(title: "Password", field: "userPassword", help: l+"help-user-password.html") {
-        f.password("value":my.userPassword)
+        f.password("value":instance.userPassword)
     }
-    descriptor = my.descriptor
+    descriptor = instance.descriptor
     f.validateButton(title: "Test Connection", progress: "Trying to connect...", method: "testConnection",
             with: "serverUri,userName,userPassword")
 
     f.entry(title: "Exchange Name", field: "exchangeName", help: l+"help-exchange-name.html") {
-        f.textbox("value":my.exchangeName)
+        f.textbox("value":instance.exchangeName)
     }
     f.entry(title: "Virtual host", field: "virtualHost", help: l+"help-virtual-host.html") {
-        f.textbox("value":my.virtualHost)
+        f.textbox("value":instance.virtualHost)
     }
     f.entry(title: "Routing Key", field: "routingKey", help: l+"help-routing-key.html") {
-        f.textbox("value":my.routingKey)
+        f.textbox("value":instance.routingKey)
     }
     f.entry(title: "Application Id", field: "appId", help: l+"help-application-id.html") {
-        f.textbox("value":my.appId)
+        f.textbox("value":instance.appId)
     }
     f.entry(title: "Persistent Delivery mode", help: l+"help-persistent-delivery.html") {
-        f.checkbox(field: "persistentDelivery", checked: my.persistentDelivery)
+        f.checkbox(field: "persistentDelivery", checked: instance.persistentDelivery)
     }
     f.entry(title: "Enable verbose logging", help: l+"help-enable-verbose-logging.html") {
-        f.checkbox(field: "enableVerboseLogging", checked: my.enableVerboseLogging)
+        f.checkbox(field: "enableVerboseLogging", checked: instance.enableVerboseLogging)
     }
 }

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConfigurationAsCodeTest.java
@@ -1,0 +1,55 @@
+package com.sonymobile.jenkins.plugins.mq.mqnotifier;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class ConfigurationAsCodeTest {
+
+    /**
+     * Configure a Jenkins rule with configuration as code installed.
+     */
+    @ClassRule
+    @ConfiguredWithCode("configuration-as-code.yml")
+    public static JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    public void shouldSupportConfigurationAsCode() {
+        MQNotifierConfig config = MQNotifierConfig.getInstance();
+        /* assertAll not available in junit 4 */
+        assertEquals("hampus", config.getUserName());
+        assertEquals("elasticsearch.tools.axis.com", config.getServerUri());
+        assertEquals("jenkins", config.getRoutingKey());
+        assertFalse(config.getEnableNotifier());
+        assertFalse(config.getPersistentDelivery());
+        assertTrue(config.getEnableVerboseLogging());
+    }
+
+    @Test
+    public void shouldSupportConfigurationExport() throws Exception {
+        MQNotifierConfig config = MQNotifierConfig.getInstance();
+        config.setUserName("hampus");
+        config.setServerUri("elasticsearch.tools.axis.com");
+        config.setExchangeName("test");
+        config.setEnableNotifier(false);
+        config.setRoutingKey("jenkins");
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        CNode mqNotifierAttr = getUnclassifiedRoot(context).get("mqNotifier");
+        String exported = toYamlString(mqNotifierAttr).replaceFirst("password: \".*\"", "");
+        String expected = toStringFromYamlFile(this, "expected-config.yml");
+        assertEquals(expected, exported);
+    }
+
+}

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConfigurationAsCodeTest.java
@@ -29,8 +29,8 @@ public class ConfigurationAsCodeTest {
     public void shouldSupportConfigurationAsCode() {
         MQNotifierConfig config = MQNotifierConfig.getInstance();
         /* assertAll not available in junit 4 */
-        assertEquals("hampus", config.getUserName());
-        assertEquals("elasticsearch.tools.axis.com", config.getServerUri());
+        assertEquals("johndoe", config.getUserName());
+        assertEquals("mq.test.com", config.getServerUri());
         assertEquals("jenkins", config.getRoutingKey());
         assertFalse(config.getEnableNotifier());
         assertFalse(config.getPersistentDelivery());
@@ -40,8 +40,8 @@ public class ConfigurationAsCodeTest {
     @Test
     public void shouldSupportConfigurationExport() throws Exception {
         MQNotifierConfig config = MQNotifierConfig.getInstance();
-        config.setUserName("hampus");
-        config.setServerUri("elasticsearch.tools.axis.com");
+        config.setUserName("johndoe");
+        config.setServerUri("mq.test.com");
         config.setExchangeName("test");
         config.setEnableNotifier(false);
         config.setRoutingKey("jenkins");

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConfigurationAsCodeTest.java
@@ -46,7 +46,7 @@ public class ConfigurationAsCodeTest {
         config.setEnableNotifier(false);
         config.setRoutingKey("jenkins");
         ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
-        CNode mqNotifierAttr = getUnclassifiedRoot(context).get("mqNotifier");
+        CNode mqNotifierAttr = getUnclassifiedRoot(context).get("mq-notifier");
         String exported = toYamlString(mqNotifierAttr).replaceFirst("password: \".*\"", "");
         String expected = toStringFromYamlFile(this, "expected-config.yml");
         assertEquals(expected, exported);

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConfigurationAsCodeTest.java
@@ -1,3 +1,26 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2022 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package com.sonymobile.jenkins.plugins.mq.mqnotifier;
 
 import io.jenkins.plugins.casc.ConfigurationContext;

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ConnectionIntegrationTest.java
@@ -1,3 +1,26 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2022 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package com.sonymobile.jenkins.plugins.mq.mqnotifier;
 
 import eu.rekawek.toxiproxy.model.ToxicDirection;

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/PluginTest.java
@@ -100,7 +100,7 @@ public class PluginTest {
         config.setEnableNotifier(false);
         config.setEnableVerboseLogging(false);
 
-        if (config != null && config.isNotifierEnabled()) {
+        if (config != null && config.getEnableNotifier()) {
             conn.initialize(
                     config.getUserName(),
                     config.getUserPassword(),
@@ -128,7 +128,7 @@ public class PluginTest {
         config.setVirtualHost(null);
         config.setEnableNotifier(true);
 
-        if (config != null && config.isNotifierEnabled()) {
+        if (config != null && config.getEnableNotifier()) {
             conn.initialize(
                     config.getUserName(),
                     config.getUserPassword(),

--- a/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/TestUtil.java
+++ b/src/test/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/TestUtil.java
@@ -1,3 +1,26 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2022 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package com.sonymobile.jenkins.plugins.mq.mqnotifier;
 
 import com.rabbitmq.client.AMQP;

--- a/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/configuration-as-code.yml
+++ b/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/configuration-as-code.yml
@@ -1,0 +1,8 @@
+unclassified:
+  mqNotifier:
+    userName: "hampus"
+    routingKey: "jenkins"
+    serverUri: "elasticsearch.tools.axis.com"
+    enableNotifier: false
+    enableVerboseLogging: true
+    persistentDelivery: false

--- a/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/configuration-as-code.yml
+++ b/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/configuration-as-code.yml
@@ -1,8 +1,8 @@
 unclassified:
   mqNotifier:
-    userName: "hampus"
+    userName: "johndoe"
     routingKey: "jenkins"
-    serverUri: "elasticsearch.tools.axis.com"
+    serverUri: "mq.test.com"
     enableNotifier: false
     enableVerboseLogging: true
     persistentDelivery: false

--- a/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/configuration-as-code.yml
+++ b/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/configuration-as-code.yml
@@ -1,5 +1,5 @@
 unclassified:
-  mqNotifier:
+  mq-notifier:
     userName: "johndoe"
     routingKey: "jenkins"
     serverUri: "mq.test.com"

--- a/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/expected-config.yml
+++ b/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/expected-config.yml
@@ -3,5 +3,5 @@ enableVerboseLogging: true
 exchangeName: "test"
 persistentDelivery: false
 routingKey: "jenkins"
-serverUri: "elasticsearch.tools.axis.com"
-userName: "hampus"
+serverUri: "mq.test.com"
+userName: "johndoe"

--- a/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/expected-config.yml
+++ b/src/test/resources/com/sonymobile/jenkins/plugins/mq/mqnotifier/expected-config.yml
@@ -1,0 +1,7 @@
+enableNotifier: false
+enableVerboseLogging: true
+exchangeName: "test"
+persistentDelivery: false
+routingKey: "jenkins"
+serverUri: "elasticsearch.tools.axis.com"
+userName: "hampus"


### PR DESCRIPTION
The following has been done to support Jenkins configuration as code:

- Extend GlobalConfig instead of deprecated Plugin, thus moving the configurable values into a descriptor.
- Setup getters in a JCasC-compatible format, otherwise the values aren't picked up.
- Add tests for JCasC config
- Upgrade Jenkins plugin version