### PR TITLE
Make task urls absolute

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ExecutorListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ExecutorListenerImpl.java
@@ -60,10 +60,10 @@ public class ExecutorListenerImpl implements ExecutorListener {
         json.put(Util.KEY_DEQUEUE_ALLOCATED_LABEL,
                 t.getAssignedLabel() != null ? t.getAssignedLabel().getDisplayName() : Util.VALUE_DEQUEUE_NO_LABEL);
 
-        json.put(Util.TASK_URL, t.getUrl());
+        json.put(Util.TASK_URL, Util.getTaskUrl(t));
         json.put(Util.TASK_IS_CONCURRENT, t.isConcurrentBuild());
         json.put(Util.TASK_OWNER_NAME, t.getOwnerTask().getDisplayName());
-        json.put(Util.TASK_OWNER_URL, t.getOwnerTask().getUrl());
+        json.put(Util.TASK_OWNER_URL, Util.getTaskUrl(t.getOwnerTask()));
 
         json.put(Util.KEY_PROJECT_NAME, Util.getFullName(t));
         json.put(Util.KEY_MASTER_FQDN, Util.getHostName());

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ExecutorListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ExecutorListenerImpl.java
@@ -104,7 +104,7 @@ public class ExecutorListenerImpl implements ExecutorListener {
         LOGGER.debug("taskCompletedWithProblems");
         JSONObject json = new JSONObject();
         populateCommon(json, executor, task);
-        json.put("state", "TASK_COMPLETED_WITH_PROBLEMS");
+        json.put("state", "TASK_COMPLETED");
         json.put(Util.TASK_DURATION, durationMS);
         json.put(Util.PROBLEMS, problems.getMessage());
         MQConnection.getInstance().publish(json);

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ExecutorListenerImpl.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/ExecutorListenerImpl.java
@@ -104,7 +104,7 @@ public class ExecutorListenerImpl implements ExecutorListener {
         LOGGER.debug("taskCompletedWithProblems");
         JSONObject json = new JSONObject();
         populateCommon(json, executor, task);
-        json.put("state", "TASK_COMPLETED");
+        json.put(Util.KEY_STATE, "TASK_COMPLETED");
         json.put(Util.TASK_DURATION, durationMS);
         json.put(Util.PROBLEMS, problems.getMessage());
         MQConnection.getInstance().publish(json);

--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/Util.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/Util.java
@@ -122,11 +122,22 @@ public final class Util {
      *
      */
     public static String getJobUrl(Queue.Item item) {
+        return getTaskUrl(item.task);
+    }
+
+    /**
+     * Get the job url for use with the REST api.
+     *
+     * @param task The queue task.
+     * @return The url.
+     *
+     */
+    public static String getTaskUrl(Queue.Task task) {
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins != null && jenkins.getRootUrl() != null) {
-            return Functions.joinPath(jenkins.getRootUrl(), item.task.getUrl());
+            return Functions.joinPath(jenkins.getRootUrl(), task.getUrl());
         } else {
-            return item.task.getUrl();
+            return task.getUrl();
         }
     }
 


### PR DESCRIPTION
By making the task urls absolute, it will be possible to make
clickable links in kibana. It also follows the conventions setup
by the other listeners.  

For easier aggregation (and keeping with the QueueListener
convention) rename TASK_COMPLETED_WITH_ERRORS
to just TASK_COMPLETED. The client can still check if errors
exists in the problems field.

<!-- Please describe your pull request here. -->

- [ x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ x ] Link to relevant issues in GitHub or Jira
- [ x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
