### PR TITLE
Derive host name from Jenkins root URL

### DIFF
--- a/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/Util.java
+++ b/src/main/java/com/sonymobile/jenkins/plugins/mq/mqnotifier/Util.java
@@ -239,9 +239,14 @@ public final class Util {
     public static String getHostName() {
         if (hostName == null) {
             try {
-                hostName = InetAddress.getLocalHost().getHostName();
-            } catch (UnknownHostException e) {
-                return VALUE_UNRESOLVED_HOST;
+                hostName = new URL(Jenkins.get().getRootUrl()).getHost();
+            } catch (MalformedURLException e) {
+                LOGGER.info("Failed to derive host name from Jenkins root URL!", e);
+                try {
+                    hostName = InetAddress.getLocalHost().getHostName();
+                } catch (UnknownHostException e2) {
+                    return VALUE_UNRESOLVED_HOST;
+                }
             }
         }
         return hostName;


### PR DESCRIPTION
It is more likely that the Jenkins root URL points to a valid host name than what is reported by the local host, e.g. if cnames are used to front a Jenkins instance with different hostname.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
